### PR TITLE
komm64(resource): track origin path on duplicate

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -415,6 +415,11 @@ Ref<Resource> Resource::_duplicate(const DuplicateParams &p_params) const {
 		AFTER_USER_CODE
 	}
 
+	// komm64: track origin path for duplicated resources (StateShot factory hook).
+	if (!resource_path.is_empty()) {
+		r->set_meta(SNAME("_origin_path"), resource_path);
+	}
+
 	return r;
 
 #undef BEFORE_USER_CODE

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -416,8 +416,9 @@ Ref<Resource> Resource::_duplicate(const DuplicateParams &p_params) const {
 	}
 
 	// komm64: track origin path for duplicated resources (StateShot factory hook).
-	if (!resource_path.is_empty()) {
-		r->set_meta(SNAME("_origin_path"), resource_path);
+	const String origin_path = get_path();
+	if (!origin_path.is_empty()) {
+		r->set_meta(SNAME("_origin_path"), origin_path);
 	}
 
 	return r;


### PR DESCRIPTION
## 動機

[k64-stateshot](https://github.com/komm64/k64-stateshot) で duplicate された Resource の起源を追跡できない。`Resource.duplicate(true)` で複製した resource は `resource_path` が空のままで、StateShot が「これは元々どの asset から来たか」を保存できない。 結果、 host 側で domain logic (~30 行) が必要になる。

GODOT_PATCHES.md Tier S #1 / Phase B-1 ウォームアップ #1。

Closes #4。

## 変更

`core/io/resource.cpp` の `Resource::_duplicate()` 末尾、 property copy 後に:

```cpp
if (!resource_path.is_empty()) {
    r->set_meta(SNAME("_origin_path"), resource_path);
}
```

## 影響範囲

- 全 duplicate path (`duplicate` / `duplicate_deep` / `duplicate_for_local_scene` / `_duplicate_from_variant`) が `_duplicate()` を経由するので 1 箇所で網羅
- 既存挙動破壊なし: 誰も `_origin_path` meta を読まなければ無視される
- anonymous sub-resource (`resource_path` 空) は対象外、 想定通り

## test

- 別途 fork base mock release (`v4.6.2-komm64-r0`) で k64-postfx _dev test 18/18 PASS の互換確認済
- merge 後 `v4.6.2-komm64-r1` tag で改造あり binary を build、 同 test 群で再確認 (これが Phase B-1 fork 運用 1 周回しの本旨)

## upstream PR

なし (個人 fork、 carry 前提)。