### PR TITLE
ci(komm64): trigger build on komm64/** branch push

### DIFF
--- a/.github/workflows/komm64-build.yml
+++ b/.github/workflows/komm64-build.yml
@@ -18,6 +18,8 @@ name: komm64 Windows Build
 on:
   workflow_dispatch:
   push:
+    branches:
+      - 'komm64/**'
     tags:
       - 'v*-komm64*'
 


### PR DESCRIPTION
## Summary
- Adds `branches: komm64/**` to the push trigger of `komm64-build.yml` so feature branches auto-build for verification before merge.
- Tag trigger (`v*-komm64*`) and `workflow_dispatch` are unchanged.

## Why
Without this, every issue's feature branch needs `gh workflow run` to manually fire CI. Since komm64/** is the established branch naming convention (see #17 `komm64/resource-duplicate-origin`), wiring it as a push trigger lets each feature branch verify itself on push.

## Test plan
- [x] YAML parses (run #25415049450 queued on push of this branch — trigger verified)
- [ ] Full build succeeds (run is in progress, doesn't gate this PR — the trigger logic is what's being verified)