### PR TITLE
komm64(material): expose ShaderMaterial.get_shader_parameter_list()

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -517,11 +517,25 @@ void ShaderMaterial::_check_material_rid() const {
 	}
 }
 
+Array ShaderMaterial::get_shader_parameter_list() const {
+	Array ret;
+	if (shader.is_null()) {
+		return ret;
+	}
+	List<PropertyInfo> uniforms;
+	shader->get_shader_uniform_list(&uniforms);
+	for (const PropertyInfo &pi : uniforms) {
+		ret.push_back(pi.operator Dictionary());
+	}
+	return ret;
+}
+
 void ShaderMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shader", "shader"), &ShaderMaterial::set_shader);
 	ClassDB::bind_method(D_METHOD("get_shader"), &ShaderMaterial::get_shader);
 	ClassDB::bind_method(D_METHOD("set_shader_parameter", "param", "value"), &ShaderMaterial::set_shader_parameter);
 	ClassDB::bind_method(D_METHOD("get_shader_parameter", "param"), &ShaderMaterial::get_shader_parameter);
+	ClassDB::bind_method(D_METHOD("get_shader_parameter_list"), &ShaderMaterial::get_shader_parameter_list);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shader", PROPERTY_HINT_RESOURCE_TYPE, "Shader"), "set_shader", "get_shader");
 }

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -127,6 +127,8 @@ public:
 	void set_shader_parameter(const StringName &p_param, const Variant &p_value);
 	Variant get_shader_parameter(const StringName &p_param) const;
 
+	Array get_shader_parameter_list() const;
+
 	virtual Shader::Mode get_shader_mode() const override;
 
 	virtual RID get_rid() const override;


### PR DESCRIPTION
Closes #5.

## Summary
Adds \`ShaderMaterial.get_shader_parameter_list() -> Array\` that returns the underlying shader's uniform list (same shape as \`Shader.get_shader_uniform_list()\`).

## Why
Saves consumers from going through \`mat.shader.get_shader_uniform_list()\` or scanning \`get_property_list()\` for \`shader_parameter/\`-prefixed entries when they need to enumerate a material's uniforms.

Used by k64-stateshot to shorten its uniform enumeration helper from ~10 lines to 1.

## Diff
2 files, +16 lines.

## Test plan
- [x] Compiles (CI verifying)
- [ ] \`mat.get_shader_parameter_list()\` returns the same entries as \`mat.shader.get_shader_uniform_list()\` for a shader with a few uniforms
- [ ] Returns empty Array when shader is null