### PR TITLE
komm64(viewport): add SubViewport.force_clear_now()

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5489,6 +5489,14 @@ void SubViewport::set_clear_mode(ClearMode p_mode) {
 	RS::get_singleton()->viewport_set_clear_mode(get_viewport_rid(), RS::ViewportClearMode(p_mode));
 }
 
+void SubViewport::force_clear_now() {
+	ERR_MAIN_THREAD_GUARD;
+	if (!is_inside_tree()) {
+		return;
+	}
+	RS::get_singleton()->viewport_set_clear_mode(get_viewport_rid(), RS::VIEWPORT_CLEAR_ONLY_NEXT_FRAME);
+}
+
 SubViewport::ClearMode SubViewport::get_clear_mode() const {
 	ERR_READ_THREAD_GUARD_V(CLEAR_MODE_ALWAYS);
 	return clear_mode;
@@ -5575,6 +5583,8 @@ void SubViewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_clear_mode", "mode"), &SubViewport::set_clear_mode);
 	ClassDB::bind_method(D_METHOD("get_clear_mode"), &SubViewport::get_clear_mode);
+
+	ClassDB::bind_method(D_METHOD("force_clear_now"), &SubViewport::force_clear_now);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size", PROPERTY_HINT_NONE, "suffix:px"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size_2d_override", PROPERTY_HINT_NONE, "suffix:px"), "set_size_2d_override", "get_size_2d_override");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -911,6 +911,8 @@ public:
 	void set_clear_mode(ClearMode p_mode);
 	ClearMode get_clear_mode() const;
 
+	void force_clear_now();
+
 	virtual Transform2D get_screen_transform_internal(bool p_absolute_position = false) const override;
 	virtual Transform2D get_popup_base_transform() const override;
 	virtual Viewport *get_section_root_viewport() const override;


### PR DESCRIPTION
Closes #7.

## Summary
Adds \`SubViewport.force_clear_now()\` — a one-shot clear API that schedules a single clear on the next render of the SubViewport without permanently changing its \`clear_mode\`.

Wraps \`RenderingServer::viewport_set_clear_mode(rid, ONLY_NEXT_FRAME)\`. The engine auto-resets the RS-side clear mode to \`CLEAR_NEVER\` after the clear runs. The SubViewport's own \`clear_mode\` member is untouched, so subsequent behavior follows whatever the user originally configured.

## Why
Replaces the multi-frame addon-side dance (toggle visibility / set CLEAR_MODE_ONCE / set UPDATE_ONCE / await 2 frames / restore) for cases where a SubViewport is already updating and the caller just wants its framebuffer cleared between feedback / ping-pong stages or snapshot transitions.

## Caveat
If \`update_mode == UPDATE_DISABLED\`, the next render never happens, so the clear is queued forever. Caller is responsible for ensuring the viewport renders. This matches the existing semantics of \`set_clear_mode(CLEAR_MODE_ONCE)\`.

## Diff
2 files, +12 lines.

## Test plan
- [x] Compiles (CI verifying)
- [ ] Existing children rendered into a SubViewport disappear from the texture after \`force_clear_now()\` + 1 frame
- [ ] \`get_clear_mode()\` returns the originally-set value before and after the call