### PR TITLE
komm64(audio): add AudioServer.export_state/import_state (bus+volume)

### DIFF
--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1026,6 +1026,36 @@ float AudioServer::get_bus_volume_linear(int p_bus) const {
 	return Math::db_to_linear(get_bus_volume_db(p_bus));
 }
 
+Dictionary AudioServer::export_state() const {
+	Dictionary state;
+	Array buses_state;
+	for (int i = 0; i < get_bus_count(); i++) {
+		Dictionary bus;
+		bus["name"] = get_bus_name(i);
+		bus["volume_db"] = get_bus_volume_db(i);
+		buses_state.push_back(bus);
+	}
+	state["buses"] = buses_state;
+	return state;
+}
+
+void AudioServer::import_state(const Dictionary &p_state) {
+	if (!p_state.has("buses")) {
+		return;
+	}
+	Array buses_state = p_state["buses"];
+	int count = MIN((int)buses_state.size(), get_bus_count());
+	for (int i = 0; i < count; i++) {
+		Dictionary bus = buses_state[i];
+		if (bus.has("volume_db")) {
+			set_bus_volume_db(i, bus["volume_db"]);
+		}
+		if (bus.has("name")) {
+			set_bus_name(i, bus["name"]);
+		}
+	}
+}
+
 int AudioServer::get_bus_channels(int p_bus) const {
 	ERR_FAIL_INDEX_V(p_bus, buses.size(), 0);
 	return buses[p_bus]->channels.size();
@@ -2039,6 +2069,9 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bus_volume_linear", "bus_idx", "volume_linear"), &AudioServer::set_bus_volume_linear);
 	ClassDB::bind_method(D_METHOD("get_bus_volume_linear", "bus_idx"), &AudioServer::get_bus_volume_linear);
+
+	ClassDB::bind_method(D_METHOD("export_state"), &AudioServer::export_state);
+	ClassDB::bind_method(D_METHOD("import_state", "state"), &AudioServer::import_state);
 
 	ClassDB::bind_method(D_METHOD("set_bus_send", "bus_idx", "send"), &AudioServer::set_bus_send);
 	ClassDB::bind_method(D_METHOD("get_bus_send", "bus_idx"), &AudioServer::get_bus_send);

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -412,6 +412,9 @@ public:
 	void set_bus_bypass_effects(int p_bus, bool p_enable);
 	bool is_bus_bypassing_effects(int p_bus) const;
 
+	Dictionary export_state() const;
+	void import_state(const Dictionary &p_state);
+
 	void add_bus_effect(int p_bus, const Ref<AudioEffect> &p_effect, int p_at_pos = -1);
 	void remove_bus_effect(int p_bus, int p_effect);
 


### PR DESCRIPTION
Closes #8.

## Summary
Adds two methods on \`AudioServer\`:

\`\`\`cpp
Dictionary export_state() const;
void import_state(const Dictionary &state);
\`\`\`

Captures bus **name + volume_db** only. Effects, sends, solo/mute, bypass are intentionally **not** included.

## Why
k64-stateshot snapshot/restore today rebuilds AudioServer bus state from an addon-side \`_bus_state\` Dictionary maintained alongside the snapshot. With this method the engine itself owns the round-trip, removing ~30 lines of addon glue.

The issue's Reality Check explicitly noted that pulling effects in is the heavy part; signal-based addon handling for effects is acceptable. So bus name + volume_db is the high-value, low-cost slice.

## Dictionary shape

\`\`\`
{ "buses": [ {"name": "Master", "volume_db": 0.0}, {"name": "Music", "volume_db": -6.0}, ... ] }
\`\`\`

The top-level dict + \`buses\` array leaves room for future fields (effects, sends, etc.) without breaking existing snapshots.

## Behavior
- \`export_state()\`: iterates \`get_bus_count()\` buses, emits {name, volume_db} for each.
- \`import_state(state)\`: index-based, applies volume_db then name to \`min(state.buses.size, current_bus_count)\` entries. Bus structure (count, ordering) is preserved as-is — caller is responsible for ensuring the bus layout matches before importing.

## Diff
2 files, +36 lines.

## Test plan
- [x] komm64 Windows Build (CI verifying)
- [ ] GDScript: \`AudioServer.export_state()\` returns dict with \`buses\` array of correct length
- [ ] GDScript: round trip — change a bus's volume_db, snapshot, change again, restore — value matches snapshot
- [ ] GDScript: import with mismatched bus count silently truncates, doesn't crash