### PR TITLE
komm64(scene): _save_state / _load_state on Audio/AnimationPlayer

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -719,6 +719,35 @@ double AnimationPlayer::get_current_animation_position() const {
 	return playback.current.pos;
 }
 
+Dictionary AnimationPlayer::_save_state() const {
+	Dictionary state;
+	state["playing"] = is_playing();
+	state["speed_scale"] = get_speed_scale();
+	if (is_playing()) {
+		state["current_animation"] = get_current_animation();
+		state["current_animation_position"] = get_current_animation_position();
+	}
+	return state;
+}
+
+void AnimationPlayer::_load_state(const Dictionary &p_state) {
+	if (p_state.has("speed_scale")) {
+		set_speed_scale(p_state["speed_scale"]);
+	}
+	const bool was_playing = p_state.has("playing") && (bool)p_state["playing"];
+	if (was_playing && p_state.has("current_animation")) {
+		const StringName anim = p_state["current_animation"];
+		if (anim != StringName()) {
+			play(anim);
+			if (p_state.has("current_animation_position")) {
+				seek(p_state["current_animation_position"], true);
+			}
+		}
+	} else {
+		stop();
+	}
+}
+
 double AnimationPlayer::get_current_animation_length() const {
 	ERR_FAIL_NULL_V_MSG(playback.current.from, 0, "AnimationPlayer has no current animation.");
 	return playback.current.from->animation->get_length();
@@ -1021,6 +1050,9 @@ void AnimationPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_current_animation_position"), &AnimationPlayer::get_current_animation_position);
 	ClassDB::bind_method(D_METHOD("get_current_animation_length"), &AnimationPlayer::get_current_animation_length);
+
+	ClassDB::bind_method(D_METHOD("_save_state"), &AnimationPlayer::_save_state);
+	ClassDB::bind_method(D_METHOD("_load_state", "state"), &AnimationPlayer::_load_state);
 
 	ClassDB::bind_method(D_METHOD("set_section_with_markers", "start_marker", "end_marker"), &AnimationPlayer::set_section_with_markers, DEFVAL(StringName()), DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("set_section", "start_time", "end_time"), &AnimationPlayer::set_section, DEFVAL(-1), DEFVAL(-1));

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -234,6 +234,9 @@ public:
 	double get_current_animation_position() const;
 	double get_current_animation_length() const;
 
+	Dictionary _save_state() const;
+	void _load_state(const Dictionary &p_state);
+
 	void set_section_with_markers(const StringName &p_start_marker = StringName(), const StringName &p_end_marker = StringName());
 	void set_section(double p_start_time = -1, double p_end_time = -1);
 	void reset_section();

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -178,6 +178,35 @@ bool AudioStreamPlayer::get_stream_paused() const {
 	return internal->get_stream_paused();
 }
 
+Dictionary AudioStreamPlayer::_save_state() {
+	Dictionary state;
+	state["playing"] = is_playing();
+	state["playback_position"] = get_playback_position();
+	state["pitch_scale"] = get_pitch_scale();
+	state["volume_db"] = get_volume_db();
+	state["stream_paused"] = get_stream_paused();
+	return state;
+}
+
+void AudioStreamPlayer::_load_state(const Dictionary &p_state) {
+	if (p_state.has("volume_db")) {
+		set_volume_db(p_state["volume_db"]);
+	}
+	if (p_state.has("pitch_scale")) {
+		set_pitch_scale(p_state["pitch_scale"]);
+	}
+	const bool was_playing = p_state.has("playing") && (bool)p_state["playing"];
+	if (was_playing) {
+		const float pos = p_state.has("playback_position") ? (float)p_state["playback_position"] : 0.0f;
+		play(pos);
+		if (p_state.has("stream_paused")) {
+			set_stream_paused(p_state["stream_paused"]);
+		}
+	} else {
+		stop();
+	}
+}
+
 Vector<AudioFrame> AudioStreamPlayer::_get_volume_vector() {
 	Vector<AudioFrame> volume_vector;
 	// We need at most four stereo pairs (for 7.1 systems).
@@ -268,6 +297,9 @@ void AudioStreamPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_stream_paused", "pause"), &AudioStreamPlayer::set_stream_paused);
 	ClassDB::bind_method(D_METHOD("get_stream_paused"), &AudioStreamPlayer::get_stream_paused);
+
+	ClassDB::bind_method(D_METHOD("_save_state"), &AudioStreamPlayer::_save_state);
+	ClassDB::bind_method(D_METHOD("_load_state", "state"), &AudioStreamPlayer::_load_state);
 
 	ClassDB::bind_method(D_METHOD("set_max_polyphony", "max_polyphony"), &AudioStreamPlayer::set_max_polyphony);
 	ClassDB::bind_method(D_METHOD("get_max_polyphony"), &AudioStreamPlayer::get_max_polyphony);

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -106,6 +106,9 @@ public:
 	void set_stream_paused(bool p_pause);
 	bool get_stream_paused() const;
 
+	Dictionary _save_state();
+	void _load_state(const Dictionary &p_state);
+
 	bool has_stream_playback();
 	Ref<AudioStreamPlayback> get_stream_playback();
 


### PR DESCRIPTION
Closes #2 (limited scope; Tween + Audio 2D/3D variants explicitly deferred).

## Summary
Adds \`Dictionary _save_state()\` / \`void _load_state(const Dictionary &)\` to:
- \`AudioStreamPlayer\`
- \`AnimationPlayer\`

Captures the public-API runtime state needed for within-session snapshot/restore (chapter migrate, save/load).

## Why
k64-stateshot currently special-cases these classes (\`_skip_classes\`) because their internal runtime state has no public extraction path. This PR gives the engine itself ownership of the round trip:

\`\`\`
state = audio_player._save_state()  # capture
# ... time passes / chapter migrate ...
audio_player._load_state(state)     # restore
\`\`\`

Bound under the conventional \`_save_state\` / \`_load_state\` names so addons can hook via \`Object.has_method()\` without a prior class-registration step.

## Captured fields

| Class | Fields |
|---|---|
| AudioStreamPlayer | \`playing\`, \`playback_position\`, \`pitch_scale\`, \`volume_db\`, \`stream_paused\` |
| AnimationPlayer | \`playing\`, \`speed_scale\`, \`current_animation\`, \`current_animation_position\` (last 2 only when playing) |

## Out of scope (deferred)
- **AudioStreamPlayer2D / AudioStreamPlayer3D** — additional spatial state (max_distance, attenuation, panning, area_mask). Follow-up PR if use case lands.
- **Tween** — tweener queue holds live Object pointers; safe round-trip needs persistent IDs (#14). Issue's reality check noted scope is contentious.
- **AnimationPlayer queue / blend** — \`get_queue()\` and blend state are not captured; use case rarely needs them across migrate boundaries.

## Diff
4 files, +70 lines.

## Test plan
- [x] komm64 Windows Build (CI verifying)
- [ ] GDScript: \`audio_player._save_state()\` returns dict with expected keys
- [ ] Round trip: capture mid-playback, stop, change pitch, restore — playback resumes from saved position with original pitch
- [ ] AnimationPlayer: capture mid-anim, restore from idle state — same anim/position resumes
- [ ] Non-playing capture: \`_save_state()\` on idle player returns dict without crashing on missing playback