### PR TITLE
komm64(shader): whitelist blend_premul_alpha_separate in canvas_item parser

### DIFF
--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -352,7 +352,7 @@ ShaderTypes::ShaderTypes() {
 	// canvasitem render modes
 	{
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("skip_vertex_transform") });
-		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha", "disabled" });
+		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha", "premul_alpha_separate", "disabled" });
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("unshaded") });
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("light_only") });
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("world_vertex_coords") });


### PR DESCRIPTION
Hotfix for #26.

## Root cause (NOT cache pollution)

PR #19 added \`blend_premul_alpha_separate\` to:
- \`MaterialStorage::ShaderData::BlendMode\` enum (RD)
- \`blend_mode_to_blend_attachment\` blend factor wiring (RD)
- \`actions.render_mode_values["blend_premul_alpha_separate"]\` (RD canvas)
- \`CanvasShaderData::BlendMode\` enum (GLES3)
- \`glBlendFuncSeparate\` case in rasterizer (GLES3)
- \`actions.render_mode_values["blend_premul_alpha_separate"]\` (GLES3 canvas)

But missed the **parser-level whitelist** at \`servers/rendering/shader_types.cpp:355\`:

\`\`\`cpp
shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha", "disabled" });
\`\`\`

\`ShaderLanguage::_parse_shader_mode\` validates render_mode tokens against this list **before** delegating to the backend's \`render_mode_values\` map. Any canvas_item shader with \`render_mode blend_premul_alpha_separate;\` was being rejected at parse time:

\`\`\`
SHADER ERROR: Invalid render mode: 'blend_premul_alpha_separate'.
\`\`\`

## Verification of evidence chain

issue #26 reported r4-r7 release binaries fail this shader. Verified:

1. **Binary contains the patch** — \`Select-String\` on the r7 release asset finds \`blend_premul_alpha_separate\` in the .text/.rdata section (between \`blend_premul_alpha\` and \`blend_disabled\` in the GLES3 render_mode_values block).
2. **Source contains the patch** — \`4.6\` HEAD has all PR #19 changes intact.
3. **CI build log confirms compilation** — \`renderer_canvas_render_rd.cpp\`, \`storage_rd/material_storage.cpp\`, \`gles3/storage/material_storage.cpp\` all compiled in r7's tag build (cache miss, fully clean build).
4. **Real failure point** — \`shader_types.cpp:355\` whitelist, never updated by PR #19.

So issue #26's hypothesis (A: cache pollution) is incorrect. The binary has the patch; the parser blocks the new render_mode token before the backend ever sees it.

## Fix

One token added to the canvas_item blend mode option list:

\`\`\`diff
- shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha", "disabled" });
+ shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha", "premul_alpha_separate", "disabled" });
\`\`\`

The parser will accept the token, then the backend's existing \`render_mode_values["blend_premul_alpha_separate"]\` mapping (already shipped in r4) will route it to the new BlendMode enum value, which the backend's \`blend_mode_to_blend_attachment\` (RD) / \`glBlendFuncSeparate\` (GLES3) will translate to the actual blend state.

## Diff
1 file, 1 line edited.

## Test plan
- [x] komm64 Windows Build (CI verifying)
- [ ] Boot binary, load \`render_mode unshaded, blend_premul_alpha_separate;\` shader → no \`Invalid render mode\` error
- [ ] LowResAccumulator (k64-postfx#34) dogfood verify resumes

## Follow-up

A CI shader compile gate (issue #26 修復方向 #2) is a good next step but is **not** included here to keep the hotfix minimal. To be filed separately.