### PR TITLE
komm64(shader): fix ModeInfo brace-init arity for 7-option blend list

### DIFF
--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -352,7 +352,7 @@ ShaderTypes::ShaderTypes() {
 	// canvasitem render modes
 	{
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("skip_vertex_transform") });
-		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha", "premul_alpha_separate", "disabled" });
+		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), { "mix", "add", "sub", "mul", "premul_alpha", "premul_alpha_separate", "disabled" } });
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("unshaded") });
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("light_only") });
 		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("world_vertex_coords") });


### PR DESCRIPTION
Follow-up to #27. Fixes the r8 build failure (Compilation step):

\`\`\`
servers\rendering\shader_types.cpp(355): error C2664: cannot convert argument 1 from 'initializer list' to 'ShaderLanguage::ModeInfo'
note: 'ModeInfo': function does not take 8 arguments
\`\`\`

## Cause

PR #27 added \`"premul_alpha_separate"\` to the canvas_item blend mode option list, bringing the brace-init to 8 arguments (1 name + 7 options). \`ShaderLanguage::ModeInfo\` (servers/rendering/shader_language.h:895) defines fixed-arity constructors up to 6 options plus a separate \`std::initializer_list<StringName>\` overload. The 7-option brace-init matched neither.

## Fix

Wrap the options in an inner brace so the call routes to the \`std::initializer_list\` overload, which has no arity cap:

\`\`\`diff
- shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), "mix", "add", "sub", "mul", "premul_alpha", "premul_alpha_separate", "disabled" });
+ shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ PNAME("blend"), { "mix", "add", "sub", "mul", "premul_alpha", "premul_alpha_separate", "disabled" } });
\`\`\`

Behavior identical to PR #27's intent. Just a syntactic gate.

## Plan after merge

The current \`v4.6.2-komm64-r8\` tag points to PR #27's broken commit. After this PR merges, the tag will be force-moved to the new HEAD so r8 ships the working hotfix (no Release was created from the broken r8 build, so no consumer impact).

## Diff
1 file, 1 line edited (added inner braces).

## Test plan
- [x] komm64 Windows Build branch CI (verifying)
- [ ] Boot binary, load \`render_mode unshaded, blend_premul_alpha_separate;\` shader → no Invalid render mode error