### PR TITLE
ci(komm64): trigger on 4.6 push + headless shader compile gate

### DIFF
--- a/.github/workflows/komm64-build.yml
+++ b/.github/workflows/komm64-build.yml
@@ -10,6 +10,14 @@ name: komm64 Windows Build
 # Trigger:
 #   - workflow_dispatch: 手動 trigger (ad-hoc 検証用)
 #   - tag push (v*-komm64*): 自動 build + Release 作成
+#   - 4.6 push (= 通常 PR merge): build + cache populate (Release は作らない)
+#   - komm64/** branch push: feature branch 検証用 build
+#
+# 4.6 を trigger に含めるのは godot-cache-restore が default_branch (= 4.6)
+# の cache を fallback key として使うため。 4.6 を build しないと cache が
+# 一度も save されず、 全 cycle が cache miss で fully clean build (~50 min)
+# になる。 merge 後に 4.6 build を 1 回走らせて cache を populate しておくと、
+# 以降の branch CI / tag build が default_branch fallback で hit して数分。
 #
 # Output:
 #   - artifact: komm64-godot-windows-editor (60-day retention)
@@ -20,6 +28,7 @@ on:
   push:
     branches:
       - 'komm64/**'
+      - '4.6'
     tags:
       - 'v*-komm64*'
 
@@ -121,6 +130,38 @@ jobs:
         with:
           name: komm64-godot-windows-editor
           path: bin/godot.windows.editor.x86_64.exe
+
+      # Headless smoke gate for komm64 fork-specific render_modes / features.
+      # Catches the class of bug fixed in #26 — a parser whitelist out of sync
+      # with backend render_mode_values mappings. Each new komm64 render_mode
+      # / shader feature should add a line under the test_shader.gdshader.
+      - name: Shader compile gate
+        shell: bash
+        run: |
+          set -e
+          mkdir -p shader_gate_test
+          cat > shader_gate_test/project.godot <<'EOF'
+          config_version=5
+
+          [application]
+
+          config/name="shader-gate-test"
+          EOF
+          cat > shader_gate_test/test_shader.gdshader <<'EOF'
+          shader_type canvas_item;
+          render_mode unshaded, blend_premul_alpha_separate;
+          void fragment() { COLOR = vec4(0.0); }
+          EOF
+          # --import scans assets and triggers shader compile; --headless
+          # avoids GPU init. Use || true so editor's exit code (which can be
+          # non-zero on import-only paths) doesn't mask grep result.
+          ./bin/godot.windows.editor.x86_64.exe --headless --path shader_gate_test --import 2>&1 | tee shader_gate.log || true
+          if grep -qi "Invalid render mode\|Invalid stencil mode\|Shader compilation failed" shader_gate.log; then
+            echo "::error::Shader compile gate FAILED — see shader_gate.log"
+            grep -iE "Invalid render mode|Invalid stencil mode|Shader compilation failed|SHADER ERROR" shader_gate.log || true
+            exit 1
+          fi
+          echo "Shader compile gate PASS"
 
       - name: Create Release (tag push only)
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
## Summary
Two CI improvements bundled (workflow YAML only, no engine code change, no new release tag needed):

1. **Add \`4.6\` to push trigger** — bootstraps the build cache so subsequent cycles get cache hits.
2. **Headless shader compile gate** — catches the parser/backend mismatch class of bugs fixed in #26 before they ship.

## Why #1: build cache bootstrap

\`godot-cache-restore\` action uses \`default_branch\` (= \`4.6\` since the recent settings change) as the restore-key fallback. But the workflow currently never triggers on \`4.6\` push, so no cache has ever been saved under that key. Result: every build runs fully clean (~50 min), even when the source is identical to the previous build.

After this PR lands and merges to \`4.6\`, the first 4.6 build populates \`komm64-windows-editor|4.6|<sha>\` cache. From then on:
- branch CI on \`komm64/<topic>\` falls back to \`komm64-windows-editor|4.6\` → cache hit → ~5-10 min build
- tag build for \`v4.6.2-komm64-r*\` same fallback → cache hit → ~5-10 min build
- one-time penalty of one extra ~50 min build now, then permanent ~5-10x speedup

## Why #2: shader compile gate

Issue #26 happened because PR #19 added \`blend_premul_alpha_separate\` to the RD/GLES3 backend render_mode_values mappings but missed the \`ShaderLanguage::shader_modes[SHADER_CANVAS_ITEM]\` parser whitelist in \`shader_types.cpp\`. The binary built and shipped four times (r4-r7) before reecho dogfood caught the runtime parse error.

The gate generates a minimal canvas_item shader using the new render_mode and parses it via \`--headless --import\`, asserting no \`Invalid render mode\` / \`Invalid stencil mode\` / \`Shader compilation failed\` in stderr. Future PRs that add shader features must add a line under \`shader_gate_test/test_shader.gdshader\` so the gate covers them.

Cost: ~10s per build (headless boot + import + grep). Value: catches this exact bug class at build time, no more wasted release cycles.

## Diff
1 file (\`.github/workflows/komm64-build.yml\`), +41 lines (12 of which are comments explaining the rationale).

## Test plan
- [x] Branch CI runs the gate against r8's shipped patch → expected PASS (the same render_mode that's now working)
- [ ] After merge, the 4.6 build runs once and populates cache
- [ ] Next subsequent build (branch or tag) shows cache hit in log

If branch CI gate FAILS, this PR isn't ready and we have a separate bug to investigate before shipping.