### PR TITLE
komm64(rd): fix slice view base mip/layer offset in get/update copy regions

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1718,8 +1718,11 @@ Error RenderingDevice::texture_update(RID p_texture, uint32_t p_layer, const Vec
 					copy_region.buffer_offset = alloc_offset;
 					copy_region.row_pitch = region_pitch;
 					copy_region.texture_subresource.aspect = texture->read_aspect_flags.has_flag(RDD::TEXTURE_ASPECT_DEPTH_BIT) ? RDD::TEXTURE_ASPECT_DEPTH : RDD::TEXTURE_ASPECT_COLOR;
-					copy_region.texture_subresource.mipmap = mm_i;
-					copy_region.texture_subresource.layer = p_layer;
+					// Add base offsets so slice views write to the correct parent mip/layer
+					// (texture->driver_id is the parent VkImage; ImageView's subresourceRange
+					// is not consulted by vkCmdCopyBufferToImage). See issue #30.
+					copy_region.texture_subresource.mipmap = mm_i + texture->base_mipmap;
+					copy_region.texture_subresource.layer = p_layer + texture->base_layer;
 					copy_region.texture_offset = Vector3i(x, y, z);
 					copy_region.texture_region_size = Vector3i(region_logic_w, region_logic_h, 1);
 
@@ -2053,8 +2056,11 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 		for (uint32_t i = 0; i < tex->mipmaps; i++) {
 			RDD::TextureSubresource subres;
 			subres.aspect = aspect;
-			subres.layer = p_layer;
-			subres.mipmap = i;
+			// Add base offsets so slice views read the correct parent mip/layer
+			// (tex->driver_id is the parent VkImage; vkCmdCopyImageToBuffer ignores
+			// the ImageView's subresourceRange). See issue #30.
+			subres.layer = p_layer + tex->base_layer;
+			subres.mipmap = i + tex->base_mipmap;
 
 			RDD::TextureCopyableLayout &mip_layout = mip_layouts[i];
 			driver->texture_get_copyable_layout(tex->driver_id, subres, &mip_layout);
@@ -2066,8 +2072,8 @@ Vector<uint8_t> RenderingDevice::texture_get_data(RID p_texture, uint32_t p_laye
 			copy_region.buffer_offset = mip_offset;
 			copy_region.row_pitch = mip_layout.row_pitch;
 			copy_region.texture_subresource.aspect = aspect;
-			copy_region.texture_subresource.mipmap = i;
-			copy_region.texture_subresource.layer = p_layer;
+			copy_region.texture_subresource.mipmap = i + tex->base_mipmap;
+			copy_region.texture_subresource.layer = p_layer + tex->base_layer;
 			copy_region.texture_region_size.x = MAX(1u, tex->width >> i);
 			copy_region.texture_region_size.y = MAX(1u, tex->height >> i);
 			copy_region.texture_region_size.z = MAX(1u, tex->depth >> i);
@@ -2223,8 +2229,10 @@ Error RenderingDevice::texture_get_data_async(RID p_texture, uint32_t p_layer, c
 					copy_region.buffer_offset = block_write_offset;
 					copy_region.row_pitch = region_pitch;
 					copy_region.texture_subresource.aspect = tex->read_aspect_flags.has_flag(RDD::TEXTURE_ASPECT_DEPTH_BIT) ? RDD::TEXTURE_ASPECT_DEPTH : RDD::TEXTURE_ASPECT_COLOR;
-					copy_region.texture_subresource.mipmap = i;
-					copy_region.texture_subresource.layer = p_layer;
+					// Add base offsets so slice views read the correct parent mip/layer.
+					// See issue #30 (also applied in texture_get_data and texture_update).
+					copy_region.texture_subresource.mipmap = i + tex->base_mipmap;
+					copy_region.texture_subresource.layer = p_layer + tex->base_layer;
 					copy_region.texture_offset = Vector3i(x, y, z);
 					copy_region.texture_region_size = Vector3i(region_logic_w, region_logic_h, 1);
 					frames[frame].download_texture_staging_buffers.push_back(download_staging_buffers.blocks[download_staging_buffers.current].driver_id);


### PR DESCRIPTION
Closes #30.

## Bug

\`RenderingDevice::texture_create_shared_from_slice\` stores \`base_mipmap\` / \`base_layer\` on the Texture struct, but three copy-region construction sites in \`servers/rendering/rendering_device.cpp\` build subresources using slice-local indices (\`= 0\`) instead of adding the base offsets:

- \`texture_update\` (~L1721)
- \`texture_get_data\` (~L2056, ~L2069)
- \`texture_get_data_async\` (~L2226)

The driver-level VkImageView's \`subresourceRange\` is **not** consulted by \`vkCmdCopy{Buffer,Image}{ToImage,ToBuffer}\` — they operate directly on the underlying VkImage referenced by \`vk_view_create_info.image\`, which is the parent. Without the base offsets:

- \`texture_get_data(slice_view, 0)\` returns parent mip 0's bytes (truncated to slice mip size)
- \`texture_update(slice_view, ...)\` writes to parent mip 0

ImageView-aware paths (compute shaders reading/writing through \`sampler2D\` / \`image2D\` bindings) are unaffected — the ImageView's \`subresourceRange\` resolves the addressing GPU-side. Only the raw copy / readback API is broken.

## Detection

Caught by k64-postfx LowResAccumulator dev test scaffolding ([k64-postfx#45](https://github.com/komm64/k64-postfx/issues/45)). Existing addon production code went through ImageView paths and was unaffected; only when the addon added value-based unit tests via \`texture_get_data\` did the bug surface.

## Fix

Add \`tex->base_mipmap\` / \`tex->base_layer\` to subresource construction at all four sites. Identical to \`texture_resolve\`'s existing pattern (which has handled this correctly since 4.x).

## Diff
1 file, +16 / -8 (8 line edits + 8 lines of inline comments explaining why the addition is needed at each site).

## Carry-only

upstream Godot has the same bug. This is a fork carry-patch; no upstream PR planned (per fork's "not actively upstreamed" policy).

## Test plan
- [x] komm64 Windows Build branch CI (verifying compile)
- [x] Headless shader compile gate (orthogonal to RD changes, but should still pass)
- [ ] After r9 release: k64-postfx \`_dev/tests/_diagnostic_mip_chain_45.gd\` step 3 vs step 3a returns matching values (= addon-side verification)