### PR TITLE
Fix stale no-thread web audio input

### DIFF
--- a/platform/web/js/libs/audio.worklet.js
+++ b/platform/web/js/libs/audio.worklet.js
@@ -93,6 +93,8 @@ class RingBuffer {
 	}
 }
 
+const MAX_PENDING_INPUT_CHUNKS = 32;
+
 class GodotProcessor extends AudioWorkletProcessor {
 	constructor() {
 		super();
@@ -104,6 +106,7 @@ class GodotProcessor extends AudioWorkletProcessor {
 		this.output_buffer = new Float32Array();
 		this.input = null;
 		this.input_buffer = new Float32Array();
+		this.pending_input_chunks = 0;
 		this.port.onmessage = (event) => {
 			const cmd = event.data['cmd'];
 			const data = event.data['data'];
@@ -137,8 +140,11 @@ class GodotProcessor extends AudioWorkletProcessor {
 			this.notifier = null;
 		} else if (p_cmd === 'start_nothreads') {
 			this.output = new RingBuffer(p_data[0], p_data[0].length, false);
+			this.pending_input_chunks = 0;
 		} else if (p_cmd === 'chunk') {
 			this.output.write(p_data);
+		} else if (p_cmd === 'input_ack') {
+			this.pending_input_chunks = Math.max(0, this.pending_input_chunks - 1);
 		}
 	}
 
@@ -161,8 +167,18 @@ class GodotProcessor extends AudioWorkletProcessor {
 				this.input_buffer = new Float32Array(chunk);
 			}
 			if (!this.threads) {
-				GodotProcessor.write_input(this.input_buffer, input);
-				this.port.postMessage({ 'cmd': 'input', 'data': this.input_buffer });
+				// Keep the worklet-to-main-thread queue bounded. Browsers may throttle the
+				// main thread while a tab is hidden even though the audio thread continues,
+				// otherwise stale input can accumulate and be processed after focus returns.
+				if (this.pending_input_chunks < MAX_PENDING_INPUT_CHUNKS) {
+					GodotProcessor.write_input(this.input_buffer, input);
+					this.port.postMessage({
+						'cmd': 'input',
+						'data': this.input_buffer,
+						'time': currentTime,
+					});
+					this.pending_input_chunks++;
+				}
 			} else if (this.input.space_left() >= chunk) {
 				GodotProcessor.write_input(this.input_buffer, input);
 				this.input.write(this.input_buffer);

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -1298,11 +1298,11 @@ const _GodotAudio = {
 				version: 1,
 				prepareMediaElement: function (element) {
 					if (!GodotAudio.ctx || typeof HTMLMediaElement === 'undefined'
-							|| !(element instanceof HTMLMediaElement)) {
+						|| !(element instanceof HTMLMediaElement)) {
 						return false;
 					}
 					if (GodotAudio.externalInputElement
-							&& GodotAudio.externalInputElement !== element) {
+						&& GodotAudio.externalInputElement !== element) {
 						return false;
 					}
 					if (!GodotAudio.externalInput) {
@@ -2027,6 +2027,7 @@ const GodotAudioWorklet = {
 		promise: null,
 		worklet: null,
 		ring_buffer: null,
+		max_input_chunk_age: 0.1,
 
 		create: function (channels) {
 			const path = GodotConfig.locate_file('godot.audio.worklet.js');
@@ -2109,7 +2110,7 @@ const GodotAudioWorklet = {
 						rpos = 0;
 					}
 					if (to_write) {
-						buffer.set(recv_buf.subarray(high, to_write), rpos);
+						buffer.set(recv_buf.subarray(high, high + to_write), rpos);
 					}
 					in_callback(from, recv_buf.length);
 					rpos += to_write;
@@ -2140,8 +2141,15 @@ const GodotAudioWorklet = {
 						);
 					} else if (event.data['cmd'] === 'input') {
 						const buf = event.data['data'];
+						const input_time = event.data['time'];
+						GodotAudioWorklet.worklet.port.postMessage({ 'cmd': 'input_ack' });
 						if (buf.length > p_in_size) {
 							GodotRuntime.error('Input chunk is too big');
+							return;
+						}
+						if (typeof input_time === 'number' && GodotAudio.ctx
+							&& GodotAudio.ctx.currentTime - input_time
+							> GodotAudioWorklet.max_input_chunk_age) {
 							return;
 						}
 						GodotAudioWorklet.ring_buffer.receive(buf);


### PR DESCRIPTION
## Summary
- bound no-thread AudioWorklet input messages with acknowledgements
- discard input chunks older than 100 ms after main-thread throttling
- fix wrapped input-ring copy range

## Verification
- Godot Web ESLint passes for both changed files
- AudioWorklet queue simulation stays bounded at 32 and resumes after ACK
- release WebGPU template build in progress