### PR TITLE
Fix WebGPU 3D texture copy origins

### DIFF
--- a/.github/workflows/webgpu_tests.yml
+++ b/.github/workflows/webgpu_tests.yml
@@ -131,6 +131,11 @@ jobs:
           cache-name: web-webgpu-test
         continue-on-error: true
 
+      # godot-build removes editor/ for export-template builds. This job also
+      # builds an editor afterwards so it can export the shader corpus.
+      - name: Restore editor sources
+        run: git restore --source=HEAD --worktree -- editor
+
       - name: Build Linux editor (for export + SPIR-V dump)
         run: |
           scons platform=linuxbsd target=editor dev_mode=yes tests=no debug_symbols=no -j$(nproc)

--- a/.github/workflows/webgpu_tests.yml
+++ b/.github/workflows/webgpu_tests.yml
@@ -146,16 +146,18 @@ jobs:
           mkdir -p webgpu_tests/test_project/export
 
           # Install WebGPU template (editor looks for web_nothreads_release.zip)
-          mkdir -p ~/.local/share/godot/export_templates/4.6.2.dev
+          mkdir -p ~/.local/share/godot/export_templates/4.6.2.stable
           cp bin/godot.web.template_release.wasm32.nothreads.dlink.zip \
-             ~/.local/share/godot/export_templates/4.6.2.dev/web_nothreads_release.zip || true
+             ~/.local/share/godot/export_templates/4.6.2.stable/web_nothreads_release.zip
 
           # Run editor headless to import project and compile all shaders
           # GODOT_DUMP_SPIRV causes all compiled SPIR-V to be written to disk
           GODOT_DUMP_SPIRV=/tmp/spirv_dump timeout 120 \
             bin/godot.linuxbsd.editor.x86_64 \
               --headless --path webgpu_tests/test_project \
-              --export-release "WebGPU" export/index.html || true
+              --export-release "WebGPU" export/index.html
+
+          test -s webgpu_tests/test_project/export/index.html
 
           echo "SPIR-V files dumped:"
           ls -la /tmp/spirv_dump/ | head -50
@@ -166,6 +168,7 @@ jobs:
         with:
           name: spirv-dump
           path: /tmp/spirv_dump/
+          if-no-files-found: error
           retention-days: 7
 
       - name: Upload WebGPU export
@@ -173,6 +176,7 @@ jobs:
         with:
           name: webgpu-export
           path: webgpu_tests/test_project/export/
+          if-no-files-found: error
           retention-days: 7
 
   # ═══════════════════════════════════════════════════════════════════════════════

--- a/.github/workflows/webgpu_tests.yml
+++ b/.github/workflows/webgpu_tests.yml
@@ -104,6 +104,11 @@ jobs:
       - name: Verify Emscripten setup
         run: emcc -v
 
+      - name: Install glslangValidator
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y glslang-tools
+
       - name: Restore Godot build cache
         uses: ./.github/actions/godot-cache-restore
         with:

--- a/drivers/webgpu/rendering_device_driver_webgpu.cpp
+++ b/drivers/webgpu/rendering_device_driver_webgpu.cpp
@@ -82,13 +82,13 @@ static void _fence_work_done(void *p_userdata) {
 // Emscripten 4.x uses the three-argument callback while 5.x adds a message.
 // Keep both overloads so assignment to WGPUQueueWorkDoneCallback selects the
 // signature declared by the active WebGPU headers.
-static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, void *p_userdata1, void *p_userdata2) {
+[[maybe_unused]] static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, void *p_userdata1, void *p_userdata2) {
 	(void)p_status;
 	(void)p_userdata2;
 	_fence_work_done(p_userdata1);
 }
 
-static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, WGPUStringView p_message, void *p_userdata1, void *p_userdata2) {
+[[maybe_unused]] static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, WGPUStringView p_message, void *p_userdata1, void *p_userdata2) {
 	(void)p_status;
 	(void)p_message;
 	(void)p_userdata2;

--- a/drivers/webgpu/rendering_device_driver_webgpu.cpp
+++ b/drivers/webgpu/rendering_device_driver_webgpu.cpp
@@ -62,12 +62,8 @@
 // Forward declaration for timestamp readback callback (defined below command_timestamp_query_pool_reset).
 static void _timestamp_readback_callback(WGPUMapAsyncStatus p_status, WGPUStringView p_message, void *p_userdata1, void *p_userdata2);
 
-// Fence work-done callback: fires when wgpuQueueSubmit work completes on GPU.
-static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, WGPUStringView p_message, void *p_userdata1, void *p_userdata2) {
-	(void)p_status;
-	(void)p_message;
-	(void)p_userdata2;
-	WGFence *fence = (WGFence *)p_userdata1;
+static void _fence_work_done(void *p_userdata) {
+	WGFence *fence = (WGFence *)p_userdata;
 	if (!fence) {
 		return;
 	}
@@ -81,6 +77,22 @@ static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, WGPUStri
 	}
 
 	fence->signaled = true;
+}
+
+// Emscripten 4.x uses the three-argument callback while 5.x adds a message.
+// Keep both overloads so assignment to WGPUQueueWorkDoneCallback selects the
+// signature declared by the active WebGPU headers.
+static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, void *p_userdata1, void *p_userdata2) {
+	(void)p_status;
+	(void)p_userdata2;
+	_fence_work_done(p_userdata1);
+}
+
+static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, WGPUStringView p_message, void *p_userdata1, void *p_userdata2) {
+	(void)p_status;
+	(void)p_message;
+	(void)p_userdata2;
+	_fence_work_done(p_userdata1);
 }
 
 // Parse "@group(G[u]) @binding(B[u])" from a WGSL string.

--- a/drivers/webgpu/rendering_device_driver_webgpu.cpp
+++ b/drivers/webgpu/rendering_device_driver_webgpu.cpp
@@ -5819,6 +5819,12 @@ void RenderingDeviceDriverWebGPU::command_copy_buffer(CommandBufferID p_cmd_buff
 	}
 }
 
+static _FORCE_INLINE_ uint32_t _texture_copy_origin_z(const WGTexture *p_texture, uint32_t p_layer, uint32_t p_offset_z) {
+	// WebGPU folds a 3D texture's Z offset and a layered texture's array layer
+	// into the same origin.z field. RenderingDevice keeps them separate.
+	return p_texture->dimension == WGPUTextureDimension_3D ? p_offset_z : p_layer;
+}
+
 void RenderingDeviceDriverWebGPU::command_copy_texture(CommandBufferID p_cmd_buffer, TextureID p_src_texture, TextureLayout p_src_texture_layout, TextureID p_dst_texture, TextureLayout p_dst_texture_layout, VectorView<TextureCopyRegion> p_regions) {
 	WGCommandBuffer *cmd = (WGCommandBuffer *)(p_cmd_buffer.id);
 	WGTexture *src = (WGTexture *)(p_src_texture.id);
@@ -5835,13 +5841,15 @@ void RenderingDeviceDriverWebGPU::command_copy_texture(CommandBufferID p_cmd_buf
 		WGPUTexelCopyTextureInfo src_copy = {};
 		src_copy.texture = src->gpu_handle();
 		src_copy.mipLevel = region.src_subresources.mipmap;
-		src_copy.origin = { (uint32_t)region.src_offset.x, (uint32_t)region.src_offset.y, region.src_subresources.base_layer };
+		src_copy.origin = { (uint32_t)region.src_offset.x, (uint32_t)region.src_offset.y,
+			_texture_copy_origin_z(src, region.src_subresources.base_layer, (uint32_t)region.src_offset.z) };
 		src_copy.aspect = WGPUTextureAspect_All;
 
 		WGPUTexelCopyTextureInfo dst_copy = {};
 		dst_copy.texture = dst->gpu_handle();
 		dst_copy.mipLevel = region.dst_subresources.mipmap;
-		dst_copy.origin = { (uint32_t)region.dst_offset.x, (uint32_t)region.dst_offset.y, region.dst_subresources.base_layer };
+		dst_copy.origin = { (uint32_t)region.dst_offset.x, (uint32_t)region.dst_offset.y,
+			_texture_copy_origin_z(dst, region.dst_subresources.base_layer, (uint32_t)region.dst_offset.z) };
 		dst_copy.aspect = WGPUTextureAspect_All;
 
 		WGPUExtent3D extent = { (uint32_t)region.size.x, (uint32_t)region.size.y, (uint32_t)region.size.z };
@@ -6201,7 +6209,8 @@ void RenderingDeviceDriverWebGPU::command_copy_buffer_to_texture(CommandBufferID
 		WGPUTexelCopyTextureInfo dst_copy = {};
 		dst_copy.texture = dst->gpu_handle();
 		dst_copy.mipLevel = region.texture_subresource.mipmap;
-		dst_copy.origin = { (uint32_t)region.texture_offset.x, (uint32_t)region.texture_offset.y, region.texture_subresource.layer };
+		dst_copy.origin = { (uint32_t)region.texture_offset.x, (uint32_t)region.texture_offset.y,
+			_texture_copy_origin_z(dst, region.texture_subresource.layer, (uint32_t)region.texture_offset.z) };
 		dst_copy.aspect = WGPUTextureAspect_All;
 
 		WGPUExtent3D extent = { copy_w, copy_h, (uint32_t)region.texture_region_size.z };
@@ -6268,7 +6277,8 @@ void RenderingDeviceDriverWebGPU::command_copy_buffer_to_texture(CommandBufferID
 				WGPUTexelCopyTextureInfo shd_copy = {};
 				shd_copy.texture = shadow;
 				shd_copy.mipLevel = region.texture_subresource.mipmap;
-				shd_copy.origin = { (uint32_t)region.texture_offset.x, (uint32_t)region.texture_offset.y, region.texture_subresource.layer };
+				shd_copy.origin = { (uint32_t)region.texture_offset.x, (uint32_t)region.texture_offset.y,
+					_texture_copy_origin_z(dst, region.texture_subresource.layer, (uint32_t)region.texture_offset.z) };
 				shd_copy.aspect = WGPUTextureAspect_All;
 
 				uint32_t s_aligned_bpr = ((region.row_pitch + 255) / 256) * 256;
@@ -6347,7 +6357,8 @@ void RenderingDeviceDriverWebGPU::command_copy_buffer_to_texture_layered(Command
 	dst_copy.texture = dst->gpu_handle();
 	dst_copy.mipLevel = p_base_region.texture_subresource.mipmap;
 	// .origin.z is the starting array layer; extent.depthOrArrayLayers covers N.
-	dst_copy.origin = { (uint32_t)p_base_region.texture_offset.x, (uint32_t)p_base_region.texture_offset.y, p_base_region.texture_subresource.layer };
+	dst_copy.origin = { (uint32_t)p_base_region.texture_offset.x, (uint32_t)p_base_region.texture_offset.y,
+		_texture_copy_origin_z(dst, p_base_region.texture_subresource.layer, (uint32_t)p_base_region.texture_offset.z) };
 	dst_copy.aspect = WGPUTextureAspect_All;
 
 	WGPUExtent3D extent = { copy_w, copy_h, p_layer_count };
@@ -6474,7 +6485,8 @@ void RenderingDeviceDriverWebGPU::command_copy_texture_to_buffer(CommandBufferID
 		WGPUTexelCopyTextureInfo src_copy = {};
 		src_copy.texture = src->gpu_handle();
 		src_copy.mipLevel = region.texture_subresource.mipmap;
-		src_copy.origin = { (uint32_t)region.texture_offset.x, (uint32_t)region.texture_offset.y, region.texture_subresource.layer };
+		src_copy.origin = { (uint32_t)region.texture_offset.x, (uint32_t)region.texture_offset.y,
+			_texture_copy_origin_z(src, region.texture_subresource.layer, (uint32_t)region.texture_offset.z) };
 		src_copy.aspect = WGPUTextureAspect_All;
 
 		// WGPUTexelCopyBufferInfo combines the buffer handle + layout (Dawn API)

--- a/drivers/webgpu/rendering_device_driver_webgpu.cpp
+++ b/drivers/webgpu/rendering_device_driver_webgpu.cpp
@@ -63,7 +63,10 @@
 static void _timestamp_readback_callback(WGPUMapAsyncStatus p_status, WGPUStringView p_message, void *p_userdata1, void *p_userdata2);
 
 // Fence work-done callback: fires when wgpuQueueSubmit work completes on GPU.
-static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, void *p_userdata1, void *p_userdata2) {
+static void _fence_work_done_callback(WGPUQueueWorkDoneStatus p_status, WGPUStringView p_message, void *p_userdata1, void *p_userdata2) {
+	(void)p_status;
+	(void)p_message;
+	(void)p_userdata2;
 	WGFence *fence = (WGFence *)p_userdata1;
 	if (!fence) {
 		return;

--- a/webgpu_tests/screenshot_comparison/screenshot_tests.mjs
+++ b/webgpu_tests/screenshot_comparison/screenshot_tests.mjs
@@ -126,7 +126,7 @@ async function captureScreenshots(baseUrl) {
     // Try to launch Chrome with WebGPU
     try {
         const chrome = await chromium.launch({
-            headless: false,
+            headless: true,
             args: ['--enable-unsafe-webgpu', '--enable-features=Vulkan,UseSkiaRenderer'],
         });
         browsers.push({ name: 'chromium', browser: chrome });
@@ -138,7 +138,7 @@ async function captureScreenshots(baseUrl) {
     // Try to launch Firefox with WebGPU
     try {
         const ff = await firefox.launch({
-            headless: false,
+            headless: true,
             firefoxUserPrefs: {
                 'dom.webgpu.enabled': true,
                 'gfx.webgpu.force-enabled': true,


### PR DESCRIPTION
## Summary
- use texture depth offsets for WebGPU Texture3D copies instead of array-layer origins
- preserve array-layer origins for 2D array and cube textures
- apply the same dimension-aware mapping to buffer uploads, texture copies, readbacks, layered copies, and shadow replay
- support both Emscripten 4.x and 5.x queue-completion callback signatures
- make the WebGPU CI jobs install glslangValidator and launch screenshot browsers headlessly

## Verification
- production WebGPU template built successfully on Surface Pro 7 with Emscripten 5.0.7
- Pixtube Player WebGPU smoke test confirms PC-88 RGB64 and RGB64 HQ preserve red, green, and blue LUT axes
- all seven Pixtube Player browser regression tests pass locally and at https://pixtube.komm64.com/player/
- driver unit, resource lifecycle, scene, and shader corpus checks pass in CI
- source format and diff checks pass