### PR TITLE
Fix WebGPU command buffer lifetime

### DIFF
--- a/drivers/webgpu/rendering_device_driver_webgpu.cpp
+++ b/drivers/webgpu/rendering_device_driver_webgpu.cpp
@@ -2944,7 +2944,9 @@ Error RenderingDeviceDriverWebGPU::command_queue_execute_and_present(CommandQueu
 		}
 	}
 
-	// Clear finished command buffers (they are consumed by submit).
+	// Release finished command buffers after submit. Queue submission retains
+	// everything needed for execution, but does not transfer ownership of the
+	// command buffer handles to the queue.
 	for (uint32_t i = 0; i < p_cmd_buffers.size(); i++) {
 		WGCommandBuffer *cmd = (WGCommandBuffer *)(p_cmd_buffers[i].id);
 		if (cmd) {
@@ -2968,6 +2970,9 @@ Error RenderingDeviceDriverWebGPU::command_queue_execute_and_present(CommandQueu
 				}
 			}
 			cmd->written_query_pools.clear();
+			if (cmd->finished_buffer) {
+				wgpuCommandBufferRelease(cmd->finished_buffer);
+			}
 			cmd->finished_buffer = nullptr;
 		}
 	}
@@ -2986,18 +2991,52 @@ RDD::CommandPoolID RenderingDeviceDriverWebGPU::command_pool_create(CommandQueue
 	return CommandPoolID(pool);
 }
 
+static void _command_buffer_reset(WGCommandBuffer *p_cmd) {
+	p_cmd->end_active_encoder();
+
+	if (p_cmd->encoder) {
+		wgpuCommandEncoderRelease(p_cmd->encoder);
+		p_cmd->encoder = nullptr;
+	}
+	if (p_cmd->finished_buffer) {
+		wgpuCommandBufferRelease(p_cmd->finished_buffer);
+		p_cmd->finished_buffer = nullptr;
+	}
+
+	p_cmd->written_query_pools.clear();
+
+	p_cmd->push_constants_dirty = false;
+	p_cmd->push_constant_data_len = 0;
+	p_cmd->invalidate_bind_groups();
+}
+
 bool RenderingDeviceDriverWebGPU::command_pool_reset(CommandPoolID p_cmd_pool) {
-	// Nothing to reset — each command buffer creates its own encoder.
+	WGCommandPool *pool = (WGCommandPool *)(p_cmd_pool.id);
+	ERR_FAIL_NULL_V(pool, false);
+
+	for (WGCommandBuffer *cmd : pool->command_buffers) {
+		_command_buffer_reset(cmd);
+	}
 	return true;
 }
 
 void RenderingDeviceDriverWebGPU::command_pool_free(CommandPoolID p_cmd_pool) {
 	WGCommandPool *pool = (WGCommandPool *)(p_cmd_pool.id);
+	ERR_FAIL_NULL(pool);
+
+	for (WGCommandBuffer *cmd : pool->command_buffers) {
+		_command_buffer_reset(cmd);
+		delete cmd;
+	}
 	delete pool;
 }
 
 RDD::CommandBufferID RenderingDeviceDriverWebGPU::command_buffer_create(CommandPoolID p_cmd_pool) {
+	WGCommandPool *pool = (WGCommandPool *)(p_cmd_pool.id);
+	ERR_FAIL_NULL_V(pool, CommandBufferID());
+
 	WGCommandBuffer *cmd = new WGCommandBuffer();
+	pool->command_buffers.push_back(cmd);
 	return CommandBufferID(cmd);
 }
 
@@ -3005,14 +3044,13 @@ bool RenderingDeviceDriverWebGPU::command_buffer_begin(CommandBufferID p_cmd_buf
 	WGCommandBuffer *cmd = (WGCommandBuffer *)(p_cmd_buffer.id);
 	ERR_FAIL_NULL_V(cmd, false);
 
+	_command_buffer_reset(cmd);
+
 	WGPUCommandEncoderDescriptor desc = {};
 	cmd->encoder = wgpuDeviceCreateCommandEncoder(device, &desc);
 	ERR_FAIL_COND_V(cmd->encoder == nullptr, false);
 
 	cmd->active_encoder = WGCommandBuffer::NONE;
-	cmd->push_constants_dirty = false;
-	cmd->push_constant_data_len = 0;
-	cmd->invalidate_bind_groups();
 
 	return true;
 }

--- a/drivers/webgpu/webgpu_objects.h
+++ b/drivers/webgpu/webgpu_objects.h
@@ -334,8 +334,11 @@ struct WGCommandQueue {
 	WGPUQueue queue = nullptr;
 };
 
+struct WGCommandBuffer;
+
 struct WGCommandPool {
 	RDD::CommandBufferType buffer_type = RDD::COMMAND_BUFFER_TYPE_PRIMARY;
+	LocalVector<WGCommandBuffer *> command_buffers;
 };
 
 struct WGQueryPool; // Forward declaration for WGCommandBuffer.


### PR DESCRIPTION
## Summary
- release each finished WebGPU command-buffer handle after queue submission
- make command pools own and destroy their command-buffer wrappers
- discard unfinished encoder/buffer handles before pool reset or command-buffer re-recording

## Root cause
`wgpuQueueSubmit()` consumes the submitted commands at the WebGPU API level, but does not release the caller-owned C handle. The driver nulled `finished_buffer` without calling `wgpuCommandBufferRelease()`. With emdawnwebgpu this also left the JavaScript object-table entry alive, retaining the submitted resource graph and making WebGPU Inspector's Texture View / Bind Group counts grow continuously.

WebGPU also lacked the command-pool ownership tracking used by the Vulkan and D3D12 drivers, so command-buffer wrappers and exceptional-path handles were not reclaimed when a pool was freed or reset.

## Verification
- local production Web/Emscripten full template build passed (33m41s)
- Pixtube Player release export passed; exported main/side WASM hashes match the new template
- direct emdawn JavaScript object-table probe on Pixtube Player with the submit-release fix:
  - 15 s: 1,917 live slots; 0 GPUCommandBuffer; 90 GPUBindGroup; 332 GPUTextureView
  - 51 s: 1,862 live slots; 0 GPUCommandBuffer; 79 GPUBindGroup; 310 GPUTextureView
  - 434 s: unchanged at 1,862 / 0 / 79 / 310
- CI passed: driver unit tests, Chrome WebGPU resource lifecycle, Chrome/Firefox scene smoke, screenshot comparison, and shader corpus

## CI note
`Build WebGPU Template + Dump SPIR-V` built both the WebGPU template and Linux editor successfully, then failed only because the existing `GODOT_DUMP_SPIRV` export produced zero files while `upload-artifact` requires at least one. This is an existing workflow issue: recent WebGPU PR runs fail the same job for the same empty dump and it is unrelated to this lifetime change.