### PR TITLE
Fix threaded WebGPU rendering synchronization

### DIFF
--- a/servers/rendering/renderer_rd/pipeline_deferred_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_deferred_rd.h
@@ -66,7 +66,13 @@ protected:
 
 	void _start(const CreationParameters &c) {
 		free();
+#ifdef WEB_ENABLED
+		// WebGPU objects cannot be accessed from Emscripten pthread workers.
+		// Keep deferred creation synchronous on the rendering thread for Web.
+		_create(c);
+#else
 		task = WorkerThreadPool::get_singleton()->add_template_task(this, &PipelineDeferredRD::_create, c, true, "PipelineCompilation");
+#endif
 	}
 
 	void _wait() {

--- a/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
@@ -139,9 +139,15 @@ public:
 		print_line("HASH:", p_key_hash, "SOURCE:", source_name);
 #endif
 
-		// Queue a background compilation task.
+		// Browser WebGPU handles are scoped to the main JavaScript realm, so
+		// Web builds must create pipelines on the rendering thread. Other
+		// platforms keep using background compilation.
+#ifdef WEB_ENABLED
+		(creation_object->*creation_function)(p_key);
+#else
 		WorkerThreadPool::TaskID task_id = WorkerThreadPool::get_singleton()->add_template_task(creation_object, creation_function, p_key, p_high_priority, "PipelineCompilation");
 		compilation_tasks.insert(p_key_hash, task_id);
+#endif
 	}
 
 	void wait_for_pipeline(uint32_t p_key_hash) {

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -552,8 +552,19 @@ void ShaderRD::_compile_version_start(Version *p_version, int p_group) {
 	compile_data.version = p_version;
 	compile_data.group = p_group;
 
+#ifdef WEB_ENABLED
+	// Browser WebGPU objects live in the main JavaScript realm and cannot be
+	// dereferenced by Emscripten pthread workers. Compile the variants on the
+	// render thread while leaving the worker pool available to other systems
+	// such as the audio mixer.
+	for (uint32_t i = 0; i < group_to_variant_map[p_group].size(); i++) {
+		_compile_variant(i, compile_data);
+	}
+	p_version->group_compilation_tasks.write[p_group] = -1;
+#else
 	WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &ShaderRD::_compile_variant, compile_data, group_to_variant_map[p_group].size(), -1, true, SNAME("ShaderCompilation"));
 	p_version->group_compilation_tasks.write[p_group] = group_task;
+#endif
 }
 
 void ShaderRD::_compile_version_end(Version *p_version, int p_group) {
@@ -561,7 +572,13 @@ void ShaderRD::_compile_version_end(Version *p_version, int p_group) {
 		return;
 	}
 	WorkerThreadPool::GroupID group_task = p_version->group_compilation_tasks[p_group];
+#ifdef WEB_ENABLED
+	if (group_task != -1) {
+		WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
+	}
+#else
 	WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
+#endif
 	p_version->group_compilation_tasks.write[p_group] = 0;
 
 	bool all_valid = true;


### PR DESCRIPTION
## Summary
- compile `ShaderRD` variants synchronously on Web
- create deferred and hashed RenderingDevice pipelines on the rendering thread on Web
- keep background pipeline compilation unchanged on non-Web platforms

## Why
Threaded Emscripten builds run RenderingDevice worker-pool jobs in JavaScript realms that do not own the browser WebGPU handles. Shader and pipeline creation then dereference an invalid WebGPU device wrapper. Keeping those Web-only creation calls on the rendering thread preserves the threaded audio mixer without crossing WebGPU handle realms.

## Validation
- Surface Pro 7, Emscripten 4.0.10, `platform=web webgpu=yes opengl3=no threads=yes dlink_enabled=yes production=yes`
- Pixtube threaded Web export boots in Chrome/WebGPU at 60 fps
- `crossOriginIsolated=true`, Web Audio input/AudioFX ready
- processed-audio continuity test under repeated main-thread stalls: minimum/median RMS ratio 0.976